### PR TITLE
Update NOTICES file for JAXB dependency changes

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -230,13 +230,13 @@ PROJECTS
 
 JAXB Runtime
 
-  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
-  Maven coordinates: https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/2.3.3
+  Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
+  Maven coordinates: https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/4.0.0
 
 Jakarta XML Binding API
 
-  Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
-  Maven coordinates: https://repo1.maven.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/2.3.3
+  Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+  Maven coordinates: https://repo1.maven.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/4.0.0
 
 TXW2 Runtime
 


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Looking at the copyright comment in these POMs it looks like these are still under the Eclipse Distribution License:
* https://repo1.maven.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/4.0.0/jakarta.xml.bind-api-4.0.0.pom
* https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/4.0.0/jaxb-runtime-4.0.0.pom

So I update the coordinates and copyright comment. 